### PR TITLE
Clean up imports

### DIFF
--- a/demeter/metamorphosis/abstract.py
+++ b/demeter/metamorphosis/abstract.py
@@ -6,21 +6,20 @@ import pickle
 import os, sys, csv#, time
 from icecream import ic
 
-sys.path.append(os.path.abspath('../'))
 from datetime import datetime
 from abc import ABC, abstractmethod
 
-from utils.optim import GradientDescent
-from utils.constants import *
-import utils.reproducing_kernels as rk
-import utils.torchbox as tb
-import utils.vector_field_to_flow as vff
-from utils.toolbox import update_progress,format_time, get_size, fig_to_image,save_gif_with_plt
-from utils.decorators import time_it
-import utils.cost_functions as cf
-import utils.fill_saves_overview as fill_saves_overview
+from ..utils.optim import GradientDescent
+from ..utils.constants import *
+from ..utils import reproducing_kernels as rk
+from ..utils import torchbox as tb
+from ..utils import vector_field_to_flow as vff
+from ..utils.toolbox import update_progress,format_time, get_size, fig_to_image,save_gif_with_plt
+from ..utils.decorators import time_it
+from ..utils import cost_functions as cf
+from ..utils import fill_saves_overview as fill_saves_overview
 
-import metamorphosis.data_cost as dt
+from ..metamorphosis import data_cost as dt
 
 # =========================================================================
 #

--- a/demeter/metamorphosis/classic.py
+++ b/demeter/metamorphosis/classic.py
@@ -3,10 +3,10 @@ import warnings
 import matplotlib.pyplot as plt
 from math import prod
 
-from metamorphosis import Geodesic_integrator,Optimize_geodesicShooting
+from .abstract import Geodesic_integrator,Optimize_geodesicShooting
 
-from utils.constants import *
-import utils.torchbox as tb
+from ..utils.constants import *
+from ..utils import torchbox as tb
 
 class Metamorphosis_integrator(Geodesic_integrator):
     """ Class integrating over a geodesic shooting. The user can choose the method among

--- a/demeter/metamorphosis/constrained.py
+++ b/demeter/metamorphosis/constrained.py
@@ -4,11 +4,11 @@ import matplotlib.pyplot as plt
 from math import prod
 
 from abc import ABC, abstractmethod
-from metamorphosis import Geodesic_integrator,Optimize_geodesicShooting
+from .abstract import Geodesic_integrator,Optimize_geodesicShooting
 
-from utils.constants import *
-import utils.torchbox as tb
-import utils.cost_functions as cf
+from ..utils.constants import *
+from ..utils import torchbox as tb
+from ..utils import cost_functions as cf
 
 class Residual_norm_function(ABC):
 

--- a/demeter/metamorphosis/data_cost.py
+++ b/demeter/metamorphosis/data_cost.py
@@ -1,8 +1,8 @@
 import torch
 from abc import ABC, abstractmethod
 
-import utils.torchbox as tb
-import utils.cost_functions as cf
+from ..utils import torchbox as tb
+from ..utils import cost_functions as cf
 
 
 class DataCost(ABC,torch.nn.Module):

--- a/demeter/metamorphosis/load.py
+++ b/demeter/metamorphosis/load.py
@@ -2,10 +2,13 @@ import torch
 import pickle
 from icecream import ic
 
-from utils.constants import *
+from ..utils.constants import *
 from .classic import Metamorphosis_integrator, Metamorphosis_Shooting
 from .constrained import ConstrainedMetamorphosis_integrator, ConstrainedMetamorphosis_Shooting, Reduce_field_Optim
-from .joined import Weighted_joinedMask_Metamorphosis_integrator,Weighted_joinedMask_Metamorphosis_Shooting
+# TODO joined.py does not exist?
+# from .joined import Weighted_joinedMask_Metamorphosis_integrator,Weighted_joinedMask_Metamorphosis_Shooting
+
+
 def load_optimize_geodesicShooting(file_name,path=None,verbose=True):
     """ load previously saved optimisation in order to plot it later."""
 

--- a/demeter/metamorphosis/wraps.py
+++ b/demeter/metamorphosis/wraps.py
@@ -1,15 +1,15 @@
 import torch
-import __init__
+# import __init__
 import sys
 from icecream import ic
 ic(sys.path)
 
 # import metamorphosis as mt
-import metamorphosis.classic as cl
-import metamorphosis.constrained as cn
+from . import classic as cl
+from . import constrained as cn
 
-import utils.torchbox as tb
-from utils.decorators import time_it
+from  ..utils import torchbox as tb
+from ..utils.decorators import time_it
 
 @time_it
 def lddmm(source,target,residuals,

--- a/demeter/utils/cost_functions.py
+++ b/demeter/utils/cost_functions.py
@@ -1,7 +1,7 @@
 import matplotlib.pyplot as plt
 import torch
 
-import utils.torchbox as tb
+from . import torchbox as tb
 
 
 class SumSquaredDifference:

--- a/demeter/utils/decorators.py
+++ b/demeter/utils/decorators.py
@@ -2,7 +2,7 @@ import functools
 import inspect
 import warnings
 from time import time
-from utils.toolbox import  format_time
+from .toolbox import  format_time
 
 def time_it(func):
     # This function shows the execution time of

--- a/demeter/utils/fill_saves_overview.py
+++ b/demeter/utils/fill_saves_overview.py
@@ -3,8 +3,8 @@
 # from datetime import datetime
 import re
 import csv
-import metamorphosis as mt
-from utils.constants import *
+from .. import metamorphosis as mt
+from .constants import *
 
 DEFAULT_CSV_FILE,DEFAULT_PATH = 'saves_overview.csv', ROOT_DIRECTORY+'/saved_optim/'
 

--- a/demeter/utils/image_3d_visualisation.py
+++ b/demeter/utils/image_3d_visualisation.py
@@ -10,11 +10,11 @@ from numpy import newaxis
 import os
 from math import prod
 
-import utils.torchbox as tb
-from utils.constants import DLT_KW_RESIDUALS, ROOT_DIRECTORY
+from . import torchbox as tb
+from .constants import DLT_KW_RESIDUALS, ROOT_DIRECTORY
 # TODO : Ajouter Residual_norm_function à la liste des imports dans __init__.py
-from metamorphosis import Metamorphosis_Shooting,Residual_norm_function
-from utils.toolbox import save_gif_with_plt
+from ..metamorphosis import Metamorphosis_Shooting,Residual_norm_function
+from .toolbox import save_gif_with_plt
 
 from icecream import ic
 
@@ -350,8 +350,10 @@ def gridDef_3d_slider(deformation,
 
 from warnings import simplefilter
 simplefilter(action='ignore', category=DeprecationWarning)
-vedo.embedWindow('ipyvtk')
-vedo.settings.useDepthPeeling = True  # if you use transparency <1
+# XXX comment out vedo lines temporarily to avoid error (maybe vedo update?):
+# AttributeError: module 'vedo' has no attribute 'embedWindow' for some reason, maybe a change in last
+# vedo.embedWindow('ipyvtk')
+# vedo.settings.useDepthPeeling = True  # if you use transparency <1
 class deformation_grid3D_vedo:
 
     def __init__(self,show_kwargs=None,

--- a/demeter/utils/optim.py
+++ b/demeter/utils/optim.py
@@ -1,6 +1,6 @@
 import torch
 
-from utils.toolbox import update_progress
+from .toolbox import update_progress
 
 
 

--- a/demeter/utils/reproducing_kernels.py
+++ b/demeter/utils/reproducing_kernels.py
@@ -6,8 +6,8 @@ import kornia
 import kornia.filters.filter as flt
 from math import prod
 
-from utils.fft_conv import fft_conv
-from utils.decorators import deprecated
+from .fft_conv import fft_conv
+from .decorators import deprecated
 
 def fft_filter(input: torch.Tensor, kernel: torch.Tensor,
              border_type: str = 'reflect',

--- a/demeter/utils/toolbox.py
+++ b/demeter/utils/toolbox.py
@@ -4,7 +4,7 @@ import matplotlib
 import sys
 import os
 import torch
-from utils.constants import ROOT_DIRECTORY
+from .constants import ROOT_DIRECTORY
 DEFAULT_DATA_PATH = 'put_file_path_here'
 
 

--- a/demeter/utils/torchbox.py
+++ b/demeter/utils/torchbox.py
@@ -16,12 +16,12 @@ import os
 import csv
 
 # import decorators
-from utils.toolbox import rgb2gray
-import utils.bspline as mbs
-import utils.vector_field_to_flow as vff
-import utils.decorators as deco
-from utils.constants import *
-# from utils.image_3d_visualisation import image_slice
+from .toolbox import rgb2gray
+from . import bspline as mbs
+from . import vector_field_to_flow as vff
+from . import decorators as deco
+from .constants import *
+# from .utils.image_3d_visualisation import image_slice
 
 # ================================================
 #        IMAGE BASICS

--- a/demeter/utils/vector_field_to_flow.py
+++ b/demeter/utils/vector_field_to_flow.py
@@ -7,7 +7,7 @@ import torch
 from torch.nn.functional import grid_sample
 from math import log,ceil
 
-import utils.torchbox as tb
+from . import torchbox as tb
 
 
 class FieldIntegrator:

--- a/examples/__init__.py
+++ b/examples/__init__.py
@@ -1,3 +1,3 @@
 import sys, os
 # add the parent directory to the path
-sys.path.insert(0,os.path.dirname(os.path.abspath(__file__))+'/../demeter/')
+sys.path.insert(0,os.path.dirname(os.path.abspath(__file__))+'/..')


### PR DESCRIPTION
I haven't adapted the imports in the `examples` folder, yet but the idea would be to replace `import metamorphosis` by `import demeter.metamorphosis` and similarly for `utils`

With these changes, I can generate an API doc with [pdoc](https://pdoc.dev/docs/pdoc.html) see https://lesteve.github.io/Demeter_metamorphosis/ (pdoc seemed simpler to setup than sphinx in my quick and dirty attempt)